### PR TITLE
Fixes double storage to convert to long using raw bytes.

### DIFF
--- a/demo/src/main/java/com/mindsea/TweakManager.kt
+++ b/demo/src/main/java/com/mindsea/TweakManager.kt
@@ -64,11 +64,11 @@ class TweakManager {
         tweakId = "numbers_double",
         group = "Numbers",
         tweakDescription = "Double",
-        releaseValue = 300.0,
-        minValue = 0.0,
-        maxValue = 1000.0,
-        defaultTweakValue = 50.0,
-        step = 50.0
+        releaseValue = 5.0,
+        minValue = -10.0,
+        maxValue = 20.0,
+        defaultTweakValue = 2.5,
+        step = 1.0/4.0
     )
 
     val longTweak: Long by longTweak(

--- a/shakytweaks/src/main/java/com/mindsea/shakytweaks/extensions/SharedPreferences.kt
+++ b/shakytweaks/src/main/java/com/mindsea/shakytweaks/extensions/SharedPreferences.kt
@@ -27,11 +27,11 @@ package com.mindsea.shakytweaks.extensions
 import android.content.SharedPreferences
 
 fun SharedPreferences.Editor.putDouble(key: String, value: Double): SharedPreferences.Editor {
-    return this.putLong(key, java.lang.Double.doubleToRawLongBits(value))
+    return this.putLong(key, value.toRawBits())
 }
 
 fun SharedPreferences.getDouble(key: String, defaultValue: Double): Double {
-    val defaultValueAsLong = java.lang.Double.doubleToRawLongBits(defaultValue)
-    val newValue = java.lang.Double.longBitsToDouble(this.getLong(key, defaultValueAsLong))
+    val defaultValueAsLong = defaultValue.toRawBits()
+    val newValue = Double.fromBits(this.getLong(key, defaultValueAsLong))
     return if (!newValue.isNaN()) newValue else defaultValue
 }

--- a/shakytweaks/src/main/java/com/mindsea/shakytweaks/extensions/SharedPreferences.kt
+++ b/shakytweaks/src/main/java/com/mindsea/shakytweaks/extensions/SharedPreferences.kt
@@ -27,9 +27,11 @@ package com.mindsea.shakytweaks.extensions
 import android.content.SharedPreferences
 
 fun SharedPreferences.Editor.putDouble(key: String, value: Double): SharedPreferences.Editor {
-    return this.putLong(key, value.toLong())
+    return this.putLong(key, java.lang.Double.doubleToRawLongBits(value))
 }
 
 fun SharedPreferences.getDouble(key: String, defaultValue: Double): Double {
-    return this.getLong(key, defaultValue.toLong()).toDouble()
+    val defaultValueAsLong = java.lang.Double.doubleToRawLongBits(defaultValue)
+    val newValue = java.lang.Double.longBitsToDouble(this.getLong(key, defaultValueAsLong))
+    return if (!newValue.isNaN()) newValue else defaultValue
 }


### PR DESCRIPTION
The old method did a simple cast and lost any decimal (binymal?) places. Also edited the sample double tweak to show it working.

The extra NaN check is to ensure that any values stored using the old method doesn't come back as NaN.