### PR TITLE
ShakyTweaks too sensitive

### DIFF
--- a/shakytweaks/src/main/java/com/mindsea/shakytweaks/util/ShakeDetector.kt
+++ b/shakytweaks/src/main/java/com/mindsea/shakytweaks/util/ShakeDetector.kt
@@ -30,7 +30,7 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import java.lang.Math.sqrt
 
-private const val SHAKE_THRESHOLD_GRAVITY = 2.3f
+private const val SHAKE_THRESHOLD_GRAVITY = 2.7f
 private const val SHAKE_SLOPE_TIME_MS = 300
 
 /**


### PR DESCRIPTION
## Description
- I noticed that the article recommends the shake threashold to be equal to 2.7.

## Links
- [ShakyTweaks too sensitive](https://github.com/MindSea/ShakyTweaksAndroid/issues/20)